### PR TITLE
Disable autocorrect and autocapitalise

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
             </span>
         </p>
         <div id="fakebox">
-            <input type="text" id="search" name="search" autocomplete="off" spellcheck="false" placeholder="loading" disabled size="1" />
+            <input type="text" id="search" name="search" autocomplete="off" spellcheck="false" autocapitalize="off" autocorrect="off" placeholder="loading" disabled size="1" />
             <span id="clear-wrap">&nbsp;<button class="clear nopad" id="clear">×</button></span>
         </div>
         <div id="info"></div>


### PR DESCRIPTION
It's nice if my phone doesn't do "tricu" -> "tricky", etc.
Autocapitalise is more of a personal aesthetic preference, I guess.